### PR TITLE
Fill in missing svg viewBox attributes

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -18,7 +18,12 @@ gulp.task('svg', () =>
       $.svgmin(() => ({
         plugins: [
           { removeDoctype: true },
-          { addAttributesToSVGElement: { attribute: 'classNameString' } },
+          { addAttributesToSVGElement: {
+            attributes: [
+              'classNameString',
+              { viewBox: '0 0 24 24' }
+            ],
+          }},
           { removeTitle: true },
           { removeStyleElement: true },
           { removeAttrs: { attrs: ['id', 'class', 'data-name', 'fill', 'xmlns'] } },


### PR DESCRIPTION
Without having viewBox defined, svg paths don't scale to their passed width and height. In other words the svg element's size changes but the inner paths stay the same, causing clipping or alignment issues. Now svgs will scale to their passed values.

Each svg is 24x24, so filling in the same viewBox of `0 0 24 24` seems safe to do. This is done with svgo at the build step in the gulpfile.

This could cause backwards-compatibility issues so it's probably better to merge this into the next major version and not a 2.1.x version